### PR TITLE
Fix login DB connection error handling

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -64,23 +64,27 @@ class Employee
 		
 	}
 	// //users login
-	public function employeeLogin($data){
-		$email = $data['email'];
-		$email = mysqli_real_escape_string($this->db->link, $email);
-		$pass = $this->fm->validation(md5($data['pass']));
-	    $pass = mysqli_real_escape_string($this->db->link, $pass);
-	    if (empty($email) or empty($pass))
-		{
-			$msg = "<span class='text-danger'>Fields must not be empty !</span>";
-			return $msg;
-		}else{
-			$sql = "SELECT * FROM tbl_user WHERE email='$email' AND pass='$pass'";
-			$result = $this->db->select($sql);
-			if ($result != false) {
-				$value = $result->fetch_assoc();
-				Session::set("userlogin",true);
-				Session::set("user_id",$value['id']);
-				Session::set("name",$value['name']);
+        public function employeeLogin($data){
+                $email = $data['email'];
+                $email = mysqli_real_escape_string($this->db->link, $email);
+                $pass = $this->fm->validation(md5($data['pass']));
+            $pass = mysqli_real_escape_string($this->db->link, $pass);
+            if (empty($email) or empty($pass))
+                {
+                        $msg = "<span class='text-danger'>Fields must not be empty !</span>";
+                        return $msg;
+                }else{
+                        $sql = "SELECT * FROM tbl_user WHERE email='$email' AND pass='$pass'";
+                        $result = $this->db->select($sql);
+                        if ($result === false && !empty($this->db->error)) {
+                                $msg = "<span class='text-danger'>".$this->db->error."</span>";
+                                return $msg;
+                        }
+                        if ($result != false) {
+                                $value = $result->fetch_assoc();
+                                Session::set("userlogin",true);
+                                Session::set("user_id",$value['id']);
+                                Session::set("name",$value['name']);
 				Session::set("designation",$value['designation']);
 				Session::set("role",$value['role']);
 				header("Location: index.php");

--- a/libs/CrudOperation.php
+++ b/libs/CrudOperation.php
@@ -18,53 +18,73 @@ Class CrudOperation{
 	  $this->connectDB();
 	 }
 	 
-	private function connectDB(){
-		 $this->link = new mysqli($this->host, $this->user, $this->pass,$this->dbname);
-		 if(!$this->link){
-		   $this->error ="Connection fail".$this->link->connect_error;
-		  return false;
-		 }
-	 }
+       private function connectDB(){
+                try {
+                        mysqli_report(MYSQLI_REPORT_OFF);
+                        $this->link = @new mysqli($this->host, $this->user, $this->pass,$this->dbname);
+                        if ($this->link->connect_errno) {
+                                $this->error = "Connection fail: ".$this->link->connect_error;
+                                $this->link = null;
+                                return false;
+                        }
+                } catch (\mysqli_sql_exception $e) {
+                        $this->error = "Connection fail: ".$e->getMessage();
+                        $this->link = null;
+                        return false;
+                }
+       }
 	 
-	// Select or Read data
-	public function select($query){
-	  $result = $this->link->query($query) or die($this->link->error.__LINE__);
-		  if($result->num_rows > 0){
-		    return $result;
-		  }else {
-		    return false;
-		  }
-	 }
+       // Select or Read data
+       public function select($query){
+                if(!$this->link){
+                        return false;
+                }
+                $result = $this->link->query($query);
+                if($result && $result->num_rows > 0){
+                        return $result;
+                }else {
+                        return false;
+                }
+        }
  
-	// Insert data
-	public function insert($query){
-		 $insert_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($insert_row){
-		   return $insert_row;
-		 } else {
-		   return false;
-		 }
-	 }
+       // Insert data
+       public function insert($query){
+                if(!$this->link){
+                        return false;
+                }
+                $insert_row = $this->link->query($query);
+                if($insert_row){
+                        return $insert_row;
+                } else {
+                        return false;
+                }
+        }
 	  
-	// Update data
-	 public function update($query){
-	 $update_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($update_row){
-		  return $update_row;
-		 } else {
-		  return false;
-		  }
-	 }
+        // Update data
+         public function update($query){
+                if(!$this->link){
+                        return false;
+                }
+                $update_row = $this->link->query($query);
+                if($update_row){
+                        return $update_row;
+                } else {
+                        return false;
+                }
+         }
 	  
-	// Delete data
-	 public function delete($query){
-	 $delete_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($delete_row){
-		   return $delete_row;
-		 }else{
-		   return false;
-		}
-	 }
+        // Delete data
+         public function delete($query){
+                if(!$this->link){
+                        return false;
+                }
+                $delete_row = $this->link->query($query);
+                if($delete_row){
+                        return $delete_row;
+                }else{
+                        return false;
+                }
+         }
 
  //end of Crud Operation class 
 }


### PR DESCRIPTION
## Summary
- handle connection failures gracefully
- surface connection error messages in employee login

## Testing
- `php -l libs/CrudOperation.php`
- `php -l classes/Employee.php`
- `find . -name '*.php' -exec php -l {} \; | grep -i "error" || true`


------
https://chatgpt.com/codex/tasks/task_e_68804df8727c8329b9a17def5d4b948b