### PR TITLE
Fix DB connection handling

### DIFF
--- a/libs/CrudOperation.php
+++ b/libs/CrudOperation.php
@@ -14,57 +14,77 @@ Class CrudOperation{
 	 public $link;
 	 public $error;
 	 
-	 public function __construct(){
-	  $this->connectDB();
-	 }
+         public function __construct(){
+          $this->connectDB();
+         }
 	 
-	private function connectDB(){
-		 $this->link = new mysqli($this->host, $this->user, $this->pass,$this->dbname);
-		 if(!$this->link){
-		   $this->error ="Connection fail".$this->link->connect_error;
-		  return false;
-		 }
-	 }
+        private function connectDB(){
+                 try {
+                         mysqli_report(MYSQLI_REPORT_OFF);
+                         $this->link = new mysqli($this->host, $this->user, $this->pass,$this->dbname);
+                         if($this->link->connect_error){
+                           $this->error = "Connection fail: ".$this->link->connect_error;
+                           $this->link = null;
+                           return false;
+                         }
+                 } catch (\mysqli_sql_exception $e) {
+                         $this->error = "Connection fail: ".$e->getMessage();
+                         $this->link = null;
+                         return false;
+                 }
+        }
 	 
 	// Select or Read data
-	public function select($query){
-	  $result = $this->link->query($query) or die($this->link->error.__LINE__);
-		  if($result->num_rows > 0){
-		    return $result;
-		  }else {
-		    return false;
-		  }
-	 }
+        public function select($query){
+          if(!$this->link){
+            return false;
+          }
+          $result = $this->link->query($query) or die($this->link->error.__LINE__);
+          if($result->num_rows > 0){
+            return $result;
+          }else {
+            return false;
+          }
+        }
  
 	// Insert data
-	public function insert($query){
-		 $insert_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($insert_row){
-		   return $insert_row;
-		 } else {
-		   return false;
-		 }
-	 }
+        public function insert($query){
+                 if(!$this->link){
+                   return false;
+                 }
+                 $insert_row = $this->link->query($query) or die($this->link->error.__LINE__);
+                 if($insert_row){
+                   return $insert_row;
+                 } else {
+                   return false;
+                 }
+        }
 	  
 	// Update data
-	 public function update($query){
-	 $update_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($update_row){
-		  return $update_row;
-		 } else {
-		  return false;
-		  }
-	 }
+         public function update($query){
+         if(!$this->link){
+           return false;
+         }
+         $update_row = $this->link->query($query) or die($this->link->error.__LINE__);
+                 if($update_row){
+                  return $update_row;
+                 } else {
+                  return false;
+                  }
+         }
 	  
 	// Delete data
-	 public function delete($query){
-	 $delete_row = $this->link->query($query) or die($this->link->error.__LINE__);
-		 if($delete_row){
-		   return $delete_row;
-		 }else{
-		   return false;
-		}
-	 }
+         public function delete($query){
+         if(!$this->link){
+           return false;
+         }
+         $delete_row = $this->link->query($query) or die($this->link->error.__LINE__);
+                 if($delete_row){
+                   return $delete_row;
+                 }else{
+                   return false;
+                }
+         }
 
  //end of Crud Operation class 
 }


### PR DESCRIPTION
## Summary
- handle mysqli exceptions when connecting to the DB
- guard CRUD methods when there is no DB connection

## Testing
- `php -l libs/CrudOperation.php`
- `while read -r file; do php -l "$file"; done < <(find . -name '*.php') | grep -v "No syntax" | head`


------
https://chatgpt.com/codex/tasks/task_e_68812c932c048329b253e30ed7238e03