### PR TITLE
Fix login session warning

### DIFF
--- a/signin.php
+++ b/signin.php
@@ -1,7 +1,7 @@
 <?php
+ob_start();
 include_once "classes/Employee.php";
 include_once "libs/Session.php";
-ob_start();
 Session::checkLogin();
 $emp = new Employee();
 ?>


### PR DESCRIPTION
## Summary
- prevent `session_start` warning on login

## Testing
- `php -l signin.php`
- `php -l libs/Session.php`
- `php -l classes/Employee.php`
- `php -l inc/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68812e497bd08329892af13c56334270